### PR TITLE
update cluster-api to 1.8.3 for kubeadm token expiry fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chang `cluster-api` version to 1.8.3.
+
 ### Added
 
 - Add `aws-resolver-rules-operator`.

--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.8.1
+app_version: 1.8.3
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.
