### PR TITLE
Bump to cluster-api-app v1.9.0 which upgrades to CAPI v1.3.2

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.8.3
+app_version: 1.9.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1610. The new CAPI version was tested in https://github.com/giantswarm/cluster-api-app/pull/115.

## Checklist

- [ ] Update changelog in CHANGELOG.md. => I didn't. This is a GitOps repo where we don't have releases. Should we remove the changelog?!