### PR TITLE
Update silence-operator.yaml

### DIFF
--- a/flux-manifests/silence-operator.yaml
+++ b/flux-manifests/silence-operator.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: monitoring
 app_name: silence-operator
-app_version: 0.9.0
+app_version: 0.8.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
reverting https://github.com/giantswarm/capa-app-collection/commit/8400653d27fe70391acf2283b685de38401e6360 so that silences sync and grizzly E2E clusters stops paging

## Checklist

- [ ] Update changelog in CHANGELOG.md.
