### PR TITLE
Support Autoscaling for MachinePools

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.11.0
+app_version: 1.13.0
 kind: Konfigure
 metadata:
   annotations:

--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.10.0
+app_version: 1.11.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
We need to update CAPI version to 1.4.0 in order to support scaling of machine pools.

Roadmap Issue: https://github.com/giantswarm/roadmap/issues/2691
Cluster API App Release: https://github.com/giantswarm/cluster-api-app/releases/tag/v1.11.0
Upstream Release: https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.4.0

## Checklist

- [ ] Update changelog in CHANGELOG.md.