### PR TITLE
Bump to cluster-api-app v1.14.1 which fixes labels for display in Hubble UI

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.14.0
+app_version: 1.14.1
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
See https://github.com/giantswarm/cluster-api-app/pull/156, released via https://github.com/giantswarm/cluster-api-app/pull/157

## Checklist

- [ ] Update changelog in CHANGELOG.md. => skipped since we don't seem to use the changelog