### PR TITLE
Revert "update app-admission-controller to 0.21.0"

### DIFF
--- a/flux-manifests/app-admission-controller.yaml
+++ b/flux-manifests/app-admission-controller.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: app-admission-controller
-app_version: 0.21.0
+app_version: 0.20.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
This reverts commit bc788a90c98954959e2aab74b2c9f89fe535eb67 because it causes `psp removal error` problems on CAPI clusters.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
