### PR TITLE
Bump to cluster-api-app v1.15.0

### DIFF
--- a/flux-manifests/cluster-api.yaml
+++ b/flux-manifests/cluster-api.yaml
@@ -2,7 +2,7 @@ api_version: generators.giantswarm.io/v1
 app_catalog: control-plane-catalog
 app_destination_namespace: giantswarm
 app_name: cluster-api
-app_version: 1.14.1
+app_version: 1.15.0
 kind: Konfigure
 metadata:
   annotations:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2217, see release https://github.com/giantswarm/cluster-api-app/pull/169
