### PR TITLE
Remove aws-crossplane-cluster-config-operator from MCC as well

### DIFF
--- a/kustomize/konfiguration.yaml
+++ b/kustomize/konfiguration.yaml
@@ -14,7 +14,6 @@ spec:
           - app-exporter
           - app-operator
           - athena
-          - aws-crossplane-cluster-config-operator
           - aws-resolver-rules-operator
           - aws-vpc-operator
           - capa-iam-operator


### PR DESCRIPTION
See: https://github.com/giantswarm/capa-app-collection/pull/85