### PR TITLE
Cluster API: Upgrade to v4.0.1.

### DIFF
--- a/kustomize/cluster-api.yaml
+++ b/kustomize/cluster-api.yaml
@@ -20,4 +20,4 @@ spec:
     inCluster: true
   name: cluster-api
   namespace: giantswarm
-  version: 3.1.2
+  version: 4.0.1


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/3944.

Finally.